### PR TITLE
Fix typos and add feature open in webbrowser

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
--- Note: The plugin was submitted to the QGIS plugin repository where it is in process of review,
-    after it has passed it will be available in the official QGIS plugin repository
 
 # Shogun Editor for QGIS. A plugin
 
@@ -43,7 +41,7 @@ After copying just open up QGIS, activate the plugin in the plugin manager and y
     can only be used with Shogun2-Webapp installations which support basic  authentication
     * Currently the plugin only support QGIS 2.X, but a version for 3.X is in
     process of development and will be released soon
-    * Editing of an applications layertree via the plugin is not yet supported
+    * Editing of an application's layertree via the plugin is not yet supported
     * Layer styles based on custom icons in Shogun currently cannot be imported to
     QGIS, but styles with custom icons created in QGIS can be uploaded to Shogun
     * Layer styles based on font symbols are currently not supported by the plugin

--- a/src/shoguneditor/__init__.py
+++ b/src/shoguneditor/__init__.py
@@ -8,8 +8,8 @@
 
                              -------------------
         begin                : 2018-05-11
-        copyright            : (C) 2018 by terrestris GmbH & CO. KG
-        email                : jgrieb (at) terretris.de
+        copyright            : (C) 2018 by terrestris GmbH & Co. KG
+        email                : jgrieb (at) terrestris.de, info (at) terrestris.de
         git sha              : $Format:%H$
  ***************************************************************************/
 

--- a/src/shoguneditor/connection/__init__.py
+++ b/src/shoguneditor/connection/__init__.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 '''
-(c) 2018 Terrestris GmbH & CO. KG, https://www.terrestris.de/en/
+(c) 2018 terrestris GmbH & Co. KG, https://www.terrestris.de/en/
  This code is licensed under the GPL 2.0 license.
 '''
 
 __author__ = 'Jonas Grieb'
-__date__ = 'Juli 2018'
+__date__ = 'July 2018'

--- a/src/shoguneditor/connection/networkaccessmanager.py
+++ b/src/shoguneditor/connection/networkaccessmanager.py
@@ -16,8 +16,8 @@
 *                                                                         *
 ***************************************************************************
 
-Minor changes by J. Grieb (jgrieb (at) terretris.de) in 2018 for the
-shogun-editor plugin by terrestris GmbH & CO. KG (https://www.terrestris.de/en/)
+Minor changes by J. Grieb (jgrieb (at) terrestris.de) in 2018 for the
+shogun-editor plugin by terrestris GmbH & Co. KG (https://www.terrestris.de/en/)
 -> for re-using purposes better use the original code
 """
 

--- a/src/shoguneditor/connection/shogunressource.py
+++ b/src/shoguneditor/connection/shogunressource.py
@@ -474,3 +474,8 @@ class ShogunRessource:
         h = {'Content-type': 'application/x-www-form-urlencoded; charset=UTF-8'}
         response = self.http.request(url, method = 'POST', body = data, headers = h)
         self.userInfo(response[0]['status'], 'Application', 'copied')
+
+
+    def viewApplicationOnline(self, id):
+        url = self.baseurl + 'client/?id=' + str(id)
+        webbrowser.open(url)

--- a/src/shoguneditor/gui/__init__.py
+++ b/src/shoguneditor/gui/__init__.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 '''
-(c) 2018 Terrestris GmbH & CO. KG, https://www.terrestris.de/en/
+(c) 2018 terrestris GmbH & Co. KG, https://www.terrestris.de/en/
  This code is licensed under the GPL 2.0 license.
 '''
 
 __author__ = 'Jonas Grieb'
-__date__ = 'Juli 2018'
+__date__ = 'July 2018'

--- a/src/shoguneditor/gui/dialog_bases/__init__.py
+++ b/src/shoguneditor/gui/dialog_bases/__init__.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 '''
-(c) 2018 Terrestris GmbH & CO. KG, https://www.terrestris.de/en/
+(c) 2018 terrestris GmbH & Co. KG, https://www.terrestris.de/en/
  This code is licensed under the GPL 2.0 license.
 '''
 
 __author__ = 'Jonas Grieb'
-__date__ = 'Juli 2018'
+__date__ = 'July 2018'

--- a/src/shoguneditor/gui/dialog_bases/addraster.py
+++ b/src/shoguneditor/gui/dialog_bases/addraster.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
 '''
-(c) 2018 Terrestris GmbH & CO. KG, https://www.terrestris.de/en/
+(c) 2018 terrestris GmbH & Co. KG, https://www.terrestris.de/en/
  This code is licensed under the GPL 2.0 license.
 '''
 
 __author__ = 'Jonas Grieb'
-__date__ = 'Juli 2018'
+__date__ = 'July 2018'
 
 from PyQt4.QtGui import QDialog, QPushButton, QLabel
 from PyQt4 import QtCore

--- a/src/shoguneditor/gui/dialog_bases/applicationSettings.py
+++ b/src/shoguneditor/gui/dialog_bases/applicationSettings.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
 '''
-(c) 2018 Terrestris GmbH & CO. KG, https://www.terrestris.de/en/
+(c) 2018 terrestris GmbH & Co. KG, https://www.terrestris.de/en/
  This code is licensed under the GPL 2.0 license.
 '''
 
 __author__ = 'Jonas Grieb'
-__date__ = 'Juli 2018'
+__date__ = 'July 2018'
 
 from PyQt4.QtCore import QRect, Qt
 from qgis.gui import QgsExtentGroupBox

--- a/src/shoguneditor/gui/dialog_bases/connectdlg.py
+++ b/src/shoguneditor/gui/dialog_bases/connectdlg.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
 '''
-(c) 2018 Terrestris GmbH & CO. KG, https://www.terrestris.de/en/
+(c) 2018 terrestris GmbH & Co. KG, https://www.terrestris.de/en/
  This code is licensed under the GPL 2.0 license.
 '''
 
 __author__ = 'Jonas Grieb'
-__date__ = 'Juli 2018'
+__date__ = 'July 2018'
 
 from PyQt4.QtCore import QRect
 from PyQt4.QtGui import QDialog, QLabel, QLineEdit, QPushButton

--- a/src/shoguneditor/gui/dialog_bases/dockwidget.py
+++ b/src/shoguneditor/gui/dialog_bases/dockwidget.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
 '''
-(c) 2018 Terrestris GmbH & CO. KG, https://www.terrestris.de/en/
+(c) 2018 terrestris GmbH & Co. KG, https://www.terrestris.de/en/
  This code is licensed under the GPL 2.0 license.
 '''
 
 __author__ = 'Jonas Grieb'
-__date__ = 'Juli 2018'
+__date__ = 'July 2018'
 
 from PyQt4.QtCore import QRect, Qt
 from PyQt4.QtGui import QWidget, QPushButton, QDockWidget, QTreeWidget

--- a/src/shoguneditor/gui/dialog_bases/layerSettings.py
+++ b/src/shoguneditor/gui/dialog_bases/layerSettings.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
 '''
-(c) 2018 Terrestris GmbH & CO. KG, https://www.terrestris.de/en/
+(c) 2018 terrestris GmbH & Co. KG, https://www.terrestris.de/en/
  This code is licensed under the GPL 2.0 license.
 '''
 
 __author__ = 'Jonas Grieb'
-__date__ = 'Juli 2018'
+__date__ = 'July 2018'
 
 from PyQt4.QtCore import QRect, Qt
 from PyQt4 import QtGui

--- a/src/shoguneditor/gui/editor.py
+++ b/src/shoguneditor/gui/editor.py
@@ -65,7 +65,8 @@ class Editor(QObject):
             return
         actionDict = {'application':
                         ('Copy Application', 'Load all layers to QGIS',
-                        'Application Settings', 'Delete Application'),
+                        'Application Settings', 'View Application in web browser',
+                         'Delete Application'),
                     'layer':
                         ('Add Layer to QGIS','Layer Settings', 'Delete Layer'),
                     'qgisLayerReference':
@@ -91,6 +92,8 @@ class Editor(QObject):
     def connectAction(self, action, actionName, item):
         if actionName == 'Copy Application':
             action.triggered.connect(item.copyApplication)
+        elif actionName == 'View Application in web browser':
+            action.triggered.connect(lambda: item.ressource.viewApplicationOnline(item.id))
         if actionName == 'Application Settings':
             action.triggered.connect(lambda: self.showApplicationSettings(item))
         elif actionName == 'New Connection':

--- a/src/shoguneditor/gui/editor.py
+++ b/src/shoguneditor/gui/editor.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
 '''
-(c) 2018 Terrestris GmbH & CO. KG, https://www.terrestris.de/en/
+(c) 2018 terrestris GmbH & Co. KG, https://www.terrestris.de/en/
  This code is licensed under the GPL 2.0 license.
 '''
 
 __author__ = 'Jonas Grieb'
-__date__ = 'Juli 2018'
+__date__ = 'July 2018'
 
 from PyQt4.QtCore import QObject, Qt, QTimer
 from PyQt4.QtGui import QMenu, QAction, QMessageBox, QTreeWidgetItemIterator

--- a/src/shoguneditor/gui/editoritems.py
+++ b/src/shoguneditor/gui/editoritems.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
 '''
-(c) 2018 Terrestris GmbH & CO. KG, https://www.terrestris.de/en/
+(c) 2018 terrestris GmbH & Co. KG, https://www.terrestris.de/en/
  This code is licensed under the GPL 2.0 license.
 '''
 
 __author__ = 'Jonas Grieb'
-__date__ = 'Juli 2018'
+__date__ = 'July 2018'
 
 from PyQt4.QtGui import QLabel, QLineEdit, QFont, QLabel, QMessageBox, QTreeWidgetItem, QIcon
 from PyQt4.QtCore import QRect, Qt
@@ -543,7 +543,7 @@ class ApplicationItem(TreeItem):
                         self.setText(0, self.name)
 
                     #update the class internal copy of the general settings
-                    newSettings = self.ressource.updateSingleApplication(id)
+                    newSettings = self.ressource.updateSingleApplication(self.id)
                     for attr in self.settings:
                         self.settings[attr] = newSettings[attr]
 

--- a/src/shoguneditor/layerutils.py
+++ b/src/shoguneditor/layerutils.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 '''
-(c) 2018 Terrestris GmbH & CO. KG, https://www.terrestris.de/en/
+(c) 2018 terrestris GmbH & Co. KG, https://www.terrestris.de/en/
 + the last method "getLabelingAsSld()" was taken
 + from the qgis geoserver explorer plugin by
 + (C) 2016 Boundless, http://boundlessgeo.com
@@ -8,7 +8,7 @@
 '''
 
 __author__ = 'Jonas Grieb'
-__date__ = 'Juli 2018'
+__date__ = 'July 2018'
 
 
 import urllib

--- a/src/shoguneditor/metadata.txt
+++ b/src/shoguneditor/metadata.txt
@@ -7,12 +7,12 @@ qgisMaximumVersion=2.99
 description=A QGIS plugin to connect with a Shogun GIS client instance on a remote or local server and edit it's content from QGIS.
 version=0.1
 author=J. Grieb
-email=jgrieb@terrestris.de
+email=jgrieb@terrestris.de, info@terrestris.de
 
-about=A QGIS plugin to connect with a Shogun GIS client instance on a remote or local server and edit it's content from QGIS. Supports editing and creating layers and applications, upload new styles from QGIS to Shogun and more
+about=A QGIS plugin to connect with a Shogun GIS client instance on a remote or local server and edit it's content from QGIS. Supports editing and creating layers and applications, upload new styles from QGIS to Shogun and more. It's funcionalities are in some way similar to the Geoserver Exploerer plugin, but instead of accessing the base geoserver it only interacts with the Shogun2-Webapp client (RESTful) interface.
 
-tracker=http://bugs
-repository=http://repo
+tracker=https://github.com/terrestris/qgis-shogun-editor/issues
+repository=https://github.com/terrestris/qgis-shogun-editor
 # End of mandatory metadata
 
 # Recommended items:

--- a/src/shoguneditor/shogun_editor.py
+++ b/src/shoguneditor/shogun_editor.py
@@ -8,8 +8,8 @@
 
                              -------------------
         begin                : 2018-05-11
-        copyright            : (C) 2018 by terrestris GmbH & CO. KG
-        email                : jgrieb (at) terretris.de
+        copyright            : (C) 2018 by terrestris GmbH & Co. KG
+        email                : jgrieb (at) terrestris.de, info (at) terrestris.de
         git sha              : $Format:%H$
  ***************************************************************************/
 
@@ -24,7 +24,7 @@
 '''
 
 __author__ = 'Jonas Grieb'
-__date__ = 'Juli 2018'
+__date__ = 'July 2018'
 
 import os.path
 


### PR DESCRIPTION
This fixes the the issues mentioned by @marcjansen in pull request #1 - changing some typos (uppercase -lowercase), changing the testConnection method to always first try with https

Also added the feature: Open the gis client view of an application in a webbrowser